### PR TITLE
NOISSUE - Update Version For Agent to Match Latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
-	github.com/ultravioletrs/agent v0.0.0-20230530113322-0e66a3bff779
+	github.com/ultravioletrs/agent v0.0.0-20230612135417-49feeb96eefb
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/ultravioletrs/agent v0.0.0-20230530113322-0e66a3bff779 h1:dWPpMH+bvY+HmE/TM+nteSEWVFK31zxVsyxBTmi77oI=
-github.com/ultravioletrs/agent v0.0.0-20230530113322-0e66a3bff779/go.mod h1:HT1uayxCbVBmjcCtcVnbrdd8IEFO/uJBysdqF6RPr+I=
+github.com/ultravioletrs/agent v0.0.0-20230612135417-49feeb96eefb h1:mYY6Wjf/vgYwa9LRpdx79P4vB5DiGlWYbpUXFTLvcbQ=
+github.com/ultravioletrs/agent v0.0.0-20230612135417-49feeb96eefb/go.mod h1:HT1uayxCbVBmjcCtcVnbrdd8IEFO/uJBysdqF6RPr+I=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.4.1+incompatible
 ## explicit
 github.com/uber/jaeger-lib/metrics
-# github.com/ultravioletrs/agent v0.0.0-20230530113322-0e66a3bff779
+# github.com/ultravioletrs/agent v0.0.0-20230612135417-49feeb96eefb
 ## explicit; go 1.18
 github.com/ultravioletrs/agent/agent
 github.com/ultravioletrs/agent/agent/api/grpc


### PR DESCRIPTION
I was having issues on cocos but after updating the agent version on manager to use latest it okay. The error was
```bash
go: downloading github.com/ultravioletrs/agent v0.0.0-20230530113322-0e66a3bff779
github.com/ultravioletrs/cocos/computations imports
        github.com/ultravioletrs/manager/manager imports
        github.com/ultravioletrs/agent/agent: github.com/ultravioletrs/agent@v0.0.0-20230530113322-0e66a3bff779: invalid version: unknown revision 0e66a3bff779    
```